### PR TITLE
fixed for hookin -h/--help is failed

### DIFF
--- a/bin/hookin.js
+++ b/bin/hookin.js
@@ -57,7 +57,7 @@ if (!fs.existsSync(hooksPath)) {
 }
 
 
-if (process.argv.length =< 3) {
+if (process.argv.length <= 3) {
   if (process.argv[2] === "-h" || process.argv[2] === "--help") {
     usage();
   }


### PR DESCRIPTION
if you type `$hookin -h` then `process.argv` have `[ 'node', '/.../bin/hookin', '-h' ]`.
should do `usage` unless process.argv.length > 3.
